### PR TITLE
Ianoff/browsing card suspended undo

### DIFF
--- a/mobile/templates/addons.ftl
+++ b/mobile/templates/addons.ftl
@@ -1,0 +1,2 @@
+# Required by rslib github.rs when EXTRA_FTL_ROOT replaces Qt FTL.
+addons-no-updates-available = No updates available.

--- a/mobile/templates/browsing.ftl
+++ b/mobile/templates/browsing.ftl
@@ -32,3 +32,6 @@ browsing-column-2 = Column 2
 browsing-second-column-19 = Second Column (1->9)
 browsing-second-column-91 = Second Column (9->1)
 browsing-sort = Sort:
+
+# Confirmation pill after swipe/context-menu suspend (Undo is the pill action).
+browsing-card-suspended-undo = Card suspended


### PR DESCRIPTION
## Summary

Adds two mobile-only FTL strings for AnkiMobile browse row gestures (issue #10, pt 2) and for compatibility after bumping the `anki` submodule to latest `main`.

| Key | English | Use |
|-----|---------|-----|
| `browsing-card-suspended-undo` | Card suspended | Confirmation pill message after swipe/context-menu suspend (Undo is the pill action) |
| `addons-no-updates-available` | No updates available. | Required by `rslib/src/backend/github.rs` when AnkiMobile replaces Qt FTL via `EXTRA_FTL_ROOT` |

`browsing-card-suspended-undo` was intentionally kept out of core FTL ([ankitects/anki#5111](https://github.com/ankitects/anki/pull/5111)); it is mobile-only for now.

`addons-no-updates-available` already exists in Qt FTL (`anki/ftl/qt/addons.ftl`) but is not included when AnkiMobile uses `ftl/mobile` instead. Latest `anki` `main` references it from Rust, so mobile needs a copy to build.

## Linked issue

Refs [ankitects/ankimobile#10](https://github.com/ankitects/ankimobile/issues/10) (browse row gestures, pt 2)
