### PR TITLE
Add browse options strings (row details + gestures)

### DIFF
--- a/mobile/templates/browsing.ftl
+++ b/mobile/templates/browsing.ftl
@@ -26,15 +26,17 @@ browsing-notes-mode = Notes Mode
 browsing-sort-backwards = Sort Backwards
 browsing-larger-font = Larger Font
 
-# Browse options (#13): card-row detail slots + gesture assignment.
-# Card Type / Note Type reuse core card-stats-card-template / card-stats-note-type.
+# Section header in browse Options for metadata shown on each card row
 browsing-card-row-details = Card Row Details
+# Section header in browse Options for tap/swipe actions
 browsing-gestures = Gestures
+# Label for a detail slot; {$number} is 1–3
 browsing-detail-number = Detail { $number }
 browsing-hide-answers = Hide Answers
 browsing-tap = Tap
+# Second swipe-left gesture (after the primary swipe left)
 browsing-swipe-left-second = Swipe Left (Second)
-# Relative timestamps on the metadata line; {$span} is a compact timespan ("3d").
+# Shown on a card row; {$span} is a compact timespan like "3d"
 browsing-created-ago = created { $span } ago
 browsing-edited-ago = edited { $span } ago
 

--- a/mobile/templates/browsing.ftl
+++ b/mobile/templates/browsing.ftl
@@ -26,6 +26,18 @@ browsing-notes-mode = Notes Mode
 browsing-sort-backwards = Sort Backwards
 browsing-larger-font = Larger Font
 
+# Browse options (#13): card-row detail slots + gesture assignment.
+# Card Type / Note Type reuse core card-stats-card-template / card-stats-note-type.
+browsing-card-row-details = Card Row Details
+browsing-gestures = Gestures
+browsing-detail-number = Detail { $number }
+browsing-hide-answers = Hide Answers
+browsing-tap = Tap
+browsing-swipe-left-second = Swipe Left (Second)
+# Relative timestamps on the metadata line; {$span} is a compact timespan ("3d").
+browsing-created-ago = created { $span } ago
+browsing-edited-ago = edited { $span } ago
+
 ## OBSOLETE; you do not need to translate.
 browsing-column-1 = Column 1
 browsing-column-2 = Column 2


### PR DESCRIPTION
## Summary

Adds mobile-only FTL strings for AnkiMobile browse options redesign ([ankitects/ankimobile#13](https://github.com/ankitects/ankimobile/issues/13)).

| Key | English | Use |
|-----|---------|-----|
| `browsing-card-row-details` | Card Row Details | Options section header |
| `browsing-gestures` | Gestures | Options section header |
| `browsing-detail-number` | Detail { $number } | Detail slot picker titles |
| `browsing-hide-answers` | Hide Answers | Browse row preference |
| `browsing-tap` | Tap | Gesture assignment row |
| `browsing-swipe-left-second` | Swipe Left (Second) | Secondary swipe-left gesture |
| `browsing-created-ago` | created { $span } ago | Metadata line (compact timespan) |
| `browsing-edited-ago` | edited { $span } ago | Metadata line (compact timespan) |

**Intentionally not added** (reuse existing):

- Card Type → core `card-stats-card-template`
- Note Type → core `card-stats-note-type`
- Swipe Left / Right → mobile `preferences-swipe-left/right`
- Slot labels Deck / Tags / Created / Ease / etc. → existing core/mobile strings

## Linked issue

Refs [ankitects/ankimobile#13](https://github.com/ankitects/ankimobile/issues/13)


Made with [Cursor](https://cursor.com)